### PR TITLE
Change html field name for password

### DIFF
--- a/Pathfinder.py
+++ b/Pathfinder.py
@@ -9,7 +9,7 @@ file_link_tag = '.zip'
 url_download_list = list()
 url_login = 'https://paizo.com/cgi-bin/WebObjects/Store.woa/wa/DirectAction/signIn?path=paizo'
 url_account_files = 'https://paizo.com/paizo/account/assets'
-data = {'e': 'E-MAIL', 'z': 'PASSWORD'}
+data = {'e': 'E-MAIL', 'zzz': 'PASSWORD'}
 
 session = requests.Session()
 holder = change_crawler_session(url_login, data, url_account_files, session)


### PR DESCRIPTION
The name of the password html field at Paizos website has changed from z to zzz.

This was the only change I needed to make this script work in 2022. Thanks for making the script available.